### PR TITLE
Remove existing md extensions from the paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ module.exports = (request, response) => {
   const code = removeWeirdWindowsThing(removeQueryParam(urlParts[1]));
 
   response.writeHead(302, {
-    Location: `https://github.com/expo/fyi/blob/master/${code}.md`,
+    Location: `https://github.com/expo/fyi/blob/master/${removeMdExtension(code)}.md`,
   });
 
   response.end();
@@ -30,4 +30,8 @@ function removeQueryParam(text) {
 
 function removeWeirdWindowsThing(text) {
   return text.replace("%E2%80%8B", "");
+}
+
+function removeMdExtension(text) {
+  return text.replace(/\.md$/, "");
 }


### PR DESCRIPTION
This should fix these links for the existing Expo CLI versions:
![image](https://user-images.githubusercontent.com/1203991/142437282-6100ce6d-1563-489e-98f2-a3c93fab3fd6.png)

But, we probably want to be more careful when writing those links.